### PR TITLE
Fix unnecesery removing

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -290,7 +290,7 @@ def metrics(returns, benchmark=None, rf=0., display=True,
         df["benchmark"] = _utils._prepare_benchmark(
             benchmark, returns.index, rf)
 
-    df = df.dropna()
+    df = df.fillna(0)
 
     # pct multiplier
     pct = 100 if display or "internal" in kwargs else 1


### PR DESCRIPTION
The error was next:
If in one day the strategy has return, but the benchmark has no data, df will have next view (for example): 0.1 na
The old method removes the return of strategy. 
In result, if we compare the strategy to different benchmarks, we will result to different numbers in strategy return. Its frustrating.