### PR TITLE
Small changes to reporting to allow for passing rolling_period as well as filename for html download

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -40,7 +40,7 @@ except ImportError:
 
 def html(returns, benchmark=None, rf=0.,
          grayscale=False, title='Strategy Tearsheet',
-         output=None, compounded=True):
+         output=None, compounded=True, rolling_period=126):
 
     if output is None and not _utils._in_notebook():
         raise ValueError("`file` must be specified")
@@ -150,21 +150,21 @@ def html(returns, benchmark=None, rf=0.,
     _plots.rolling_volatility(returns, benchmark, grayscale=grayscale,
                               figsize=(8, 3), subtitle=False,
                               savefig={'fname': figfile, 'format': 'svg'},
-                              show=False, ylabel=False)
+                              show=False, ylabel=False, period=rolling_period)
     tpl = tpl.replace('{{rolling_vol}}', figfile.getvalue().decode())
 
     figfile = _utils._file_stream()
     _plots.rolling_sharpe(returns, grayscale=grayscale,
                           figsize=(8, 3), subtitle=False,
                           savefig={'fname': figfile, 'format': 'svg'},
-                          show=False, ylabel=False)
+                          show=False, ylabel=False, period=rolling_period)
     tpl = tpl.replace('{{rolling_sharpe}}', figfile.getvalue().decode())
 
     figfile = _utils._file_stream()
     _plots.rolling_sortino(returns, grayscale=grayscale,
                            figsize=(8, 3), subtitle=False,
                            savefig={'fname': figfile, 'format': 'svg'},
-                           show=False, ylabel=False)
+                           show=False, ylabel=False, period=rolling_period)
     tpl = tpl.replace('{{rolling_sortino}}', figfile.getvalue().decode())
 
     figfile = _utils._file_stream()
@@ -477,7 +477,8 @@ def metrics(returns, benchmark=None, rf=0., display=True,
 
 
 def plots(returns, benchmark=None, grayscale=False,
-          figsize=(8, 5), mode='basic', compounded=True):
+          figsize=(8, 5), mode='basic', compounded=True,
+          rolling_period=126):
 
     if mode.lower() != 'full':
         _plots.snapshot(returns, grayscale=grayscale,
@@ -525,15 +526,16 @@ def plots(returns, benchmark=None, grayscale=False,
 
     _plots.rolling_volatility(
         returns, benchmark, grayscale=grayscale,
-        figsize=(figsize[0], figsize[0]*.3), show=True, ylabel=False)
+        figsize=(figsize[0], figsize[0]*.3), show=True, ylabel=False,
+        period=rolling_period)
 
     _plots.rolling_sharpe(returns, grayscale=grayscale,
                           figsize=(figsize[0], figsize[0]*.3),
-                          show=True, ylabel=False)
+                          show=True, ylabel=False, period=rolling_period)
 
     _plots.rolling_sortino(returns, grayscale=grayscale,
                            figsize=(figsize[0], figsize[0]*.3),
-                           show=True, ylabel=False)
+                           show=True, ylabel=False, period=rolling_period)
 
     _plots.drawdowns_periods(returns, grayscale=grayscale,
                              figsize=(figsize[0], figsize[0]*.5),

--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -40,7 +40,8 @@ except ImportError:
 
 def html(returns, benchmark=None, rf=0.,
          grayscale=False, title='Strategy Tearsheet',
-         output=None, compounded=True, rolling_period=126):
+         output=None, compounded=True, rolling_period=126,
+         download_filename='quantstats-tearsheet.html'):
 
     if output is None and not _utils._in_notebook():
         raise ValueError("`file` must be specified")
@@ -200,7 +201,7 @@ def html(returns, benchmark=None, rf=0.,
 
     if output is None:
         # _open_html(tpl)
-        _download_html(tpl, 'quantstats-tearsheet.html')
+        _download_html(tpl, download_filename)
         return
 
     with open(output, 'w', encoding='utf-8') as f:


### PR DESCRIPTION
Issue: rolling volatility, sortinio and sharpe graphs are hardcoded with period=126 in the report and plot generation.
Code change: I made that a variable that is passed in, with default value of 126.

Issue: Downloaded report always has same name, which is not convenient and also piles up in filesystem (quantstats-tearsheet.html, quantstats-tearsheet(1).html, etc...)
Code change: Allow to pass download_filename variable, which defaults to the same 'quantstats-tearsheet.html'