### PR TITLE
Fix issue #72: Prepare returns for pandas always convert to simple returns

### DIFF
--- a/quantstats/utils.py
+++ b/quantstats/utils.py
@@ -212,7 +212,7 @@ def _prepare_returns(data, rf=0., nperiods=None):
 
     if isinstance(data, _pd.DataFrame):
         for col in data.columns:
-            if data[col].dropna().min() >= 0 or data[col].dropna().max() > 1:
+            if data[col].dropna().min() >= 0 and data[col].dropna().max() > 1:
                 data[col] = data[col].pct_change()
     elif data.min() >= 0 and data.max() > 1:
         data = data.pct_change()


### PR DESCRIPTION
https://github.com/ranaroussi/quantstats/blob/a76c1e3f5cfab91305c91f4deea132413222c3e7/quantstats/utils.py#L215

Shouldn't this be an AND instead of an OR?
As it is now, it will always convert the values from prices to percentage returns, right?

It is not the same rule that is followed by simple lists (couple of lines below). Both rules should be the same,
https://github.com/ranaroussi/quantstats/blob/a76c1e3f5cfab91305c91f4deea132413222c3e7/quantstats/utils.py#L217

This PR is supposed to fix that.

Thanks