### PR TITLE
Feat: Add make_index() for easy index creation

### DIFF
--- a/quantstats/utils.py
+++ b/quantstats/utils.py
@@ -307,6 +307,23 @@ def _score_str(val):
     """ Returns + sign for positive values (used in plots) """
     return ("" if "-" in val else "+") + str(val)
 
+def make_index(ticker_weights, period="max"):
+  """ Makes an index out of the given tickers and weights. """
+  # Declare a returns variable
+  index = None
+  # Iterate over weights
+  for ticker, ticker_weight in ticker_weights.items():
+    # Download the returns for this ticker, e.g. GOOG
+    ticker_returns = download_returns(ticker, period)
+    if index is None:
+      # Set the returns to this return series if it's empty
+      index = ticker_returns
+    else:
+      # Otherwise, add weighted return
+      index += ticker_returns * ticker_weight
+  # Return total index
+  return index
+
 
 def make_portfolio(returns, start_balance=1e5,
                    mode="comp", round_to=None):


### PR DESCRIPTION
Easily build an index for a given dictionary of weights and lookback period.

## Example
```python
FAANG = qs.utils.make_index(
    {
        'FB': 0.2,
        'AAPL': 0.2,
        'AMZN': 0.2,
        'NFLX': 0.2,
        'GOOG': 0.2
    },
)

qs.plots.snapshot(FAANG.dropna(), "SPY")
```

**Output:**
![image](https://user-images.githubusercontent.com/1657236/114147105-f6c17500-98dd-11eb-9807-19c28aca97a2.png)
