### PR TITLE
Enable period setting for adjusted sortino

### DIFF
--- a/quantstats/stats.py
+++ b/quantstats/stats.py
@@ -252,7 +252,7 @@ def adjusted_sortino(returns, rf=0, periods=252, annualize=True):
     direct comparisons to the Sharpe. See here for more info:
     https://archive.is/wip/2rwFW
     """
-    data = sortino(returns, rf=0, periods=252, annualize=True)
+    data = sortino(returns, rf=0, periods=periods, annualize=True)
     return data / _sqrt(2)
 
 

--- a/quantstats/stats.py
+++ b/quantstats/stats.py
@@ -252,7 +252,7 @@ def adjusted_sortino(returns, rf=0, periods=252, annualize=True):
     direct comparisons to the Sharpe. See here for more info:
     https://archive.is/wip/2rwFW
     """
-    data = sortino(returns, rf=0, periods=periods, annualize=True)
+    data = sortino(returns, rf=0, periods=periods, annualize=annualize)
     return data / _sqrt(2)
 
 


### PR DESCRIPTION
Adjusted Sortino is calculated with periods fixed to 252. The call to `sortino()` should use the argument from the method call instead.