### PR TITLE
Added Serenity Index and modified UPI calc

### DIFF
--- a/quantstats/__init__.py
+++ b/quantstats/__init__.py
@@ -66,6 +66,7 @@ def extend_pandas():
     _po.ulcer_index = stats.ulcer_index
     _po.ulcer_performance_index = stats.ulcer_performance_index
     _po.upi = stats.upi
+    _po.serenity_index = stats.serenity_index
     _po.risk_of_ruin = stats.risk_of_ruin
     _po.ror = stats.ror
     _po.value_at_risk = stats.value_at_risk

--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -224,7 +224,7 @@ def html(returns, benchmark=None, rf=0., grayscale=False,
 def full(returns, benchmark=None, rf=0., grayscale=False,
          figsize=(8, 5), display=True, compounded=True,
          trading_year_days=252):
-
+    
     dd = _stats.to_drawdown_series(returns)
     dd_info = _stats.drawdown_details(dd).sort_values(
         by='max drawdown', ascending=True)[:5]
@@ -454,6 +454,7 @@ def metrics(returns, benchmark=None, rf=0., display=True,
         metrics[ix] = row
     metrics['Recovery Factor'] = _stats.recovery_factor(df)
     metrics['Ulcer Index'] = _stats.ulcer_index(df, rf)
+    metrics['Serenity Index'] = _stats.serenity_index(df, rf)
 
     # win rate
     if mode.lower() == 'full':

--- a/quantstats/stats.py
+++ b/quantstats/stats.py
@@ -334,8 +334,8 @@ def calmar(returns):
 
 def ulcer_index(returns, rf=0):
     """ calculates the ulcer index score (downside risk measurment) """
-    returns = _utils._prepare_returns(returns, rf)
-    dd = 1. - returns/returns.cummax()
+
+    dd = to_drawdown_series(returns)
     return _np.sqrt(_np.divide((dd**2).sum(), returns.shape[0] - 1))
 
 
@@ -344,15 +344,24 @@ def ulcer_performance_index(returns, rf=0):
     calculates the ulcer index score
     (downside risk measurment)
     """
-    returns = _utils._prepare_returns(returns, rf)
-    dd = 1. - returns/returns.cummax()
-    ulcer = _np.sqrt(_np.divide((dd**2).sum(), returns.shape[0] - 1))
-    return returns.mean() / ulcer
+
+    return comp(returns) / ulcer_index(returns)
 
 
 def upi(returns, rf=0):
     """ shorthand for ulcer_performance_index() """
     return ulcer_performance_index(returns, rf)
+
+
+def serenity_index(returns, rf=0):
+    """
+    calculates the serenity index score
+    (https://www.keyquant.com/Download/GetFile?Filename=%5CPublications%5CKeyQuant_WhitePaper_APT_Part1.pdf)
+    """
+
+    dd = to_drawdown_series(returns)
+    pitfall = - cvar(dd) / returns.std()
+    return comp(returns) / ( ulcer_index(returns) * pitfall )  
 
 
 def risk_of_ruin(returns):
@@ -508,9 +517,9 @@ def max_drawdown(prices):
     return (prices / prices.expanding(min_periods=0).max()).min() - 1
 
 
-def to_drawdown_series(prices):
-    """ convert price series to drawdown series """
-    prices = _utils._prepare_prices(prices)
+def to_drawdown_series(returns):
+    """ convert returns series to drawdown series """
+    prices = _utils._prepare_prices(returns)
     dd = prices / _np.maximum.accumulate(prices) - 1.
     return dd.replace([_np.inf, -_np.inf, -0], 0)
 


### PR DESCRIPTION
Hi I've added to the metrics the Serenity index from this papar:
https://www.keyquant.com/Download/GetFile?Filename=%5CPublications%5CKeyQuant_WhitePaper_APT_Part1.pdf also in attachment.
[KeyQuant_WhitePaper_APT_Part1.pdf](https://github.com/ranaroussi/quantstats/files/6845975/KeyQuant_WhitePaper_APT_Part1.pdf)


I've also modified the UPI calculation, invoking the ulcer index function, removing copied code and calculating the drawdown on prices and not on daily returns 

Ciao,
Giuseppe