### PR TITLE
temporary fix for: Rf rate when not 0 metrics are incorrectly calculated due to dataframe alteration

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -398,7 +398,7 @@ def metrics(returns, benchmark=None, rf=0., display=True,
 
     metrics['Start Period'] = _pd.Series(s_start)
     metrics['End Period'] = _pd.Series(s_end)
-    metrics['Risk-Free Rate %'] = _pd.Series(s_rf)
+    metrics['Risk-Free Rate %'] = _pd.Series(s_rf)*100
     metrics['Time in Market %'] = _stats.exposure(df, prepare_returns=False) * pct
 
     metrics['~'] = blank

--- a/quantstats/utils.py
+++ b/quantstats/utils.py
@@ -23,6 +23,7 @@ import pandas as _pd
 import numpy as _np
 import yfinance as _yf
 from . import stats as _stats
+import inspect
 
 
 def _mtd(df):
@@ -208,7 +209,7 @@ def _prepare_prices(data, base=1.):
 def _prepare_returns(data, rf=0., nperiods=None):
     """Converts price data into returns + cleanup"""
     data = data.copy()
-
+    function = inspect.stack()[1][3]
     if isinstance(data, _pd.DataFrame):
         for col in data.columns:
             if data[col].dropna().min() >= 0 and data[col].dropna().max() > 1:
@@ -222,9 +223,15 @@ def _prepare_returns(data, rf=0., nperiods=None):
     if isinstance(data, (_pd.DataFrame, _pd.Series)):
         data = data.fillna(0).replace(
             [_np.inf, -_np.inf], float('NaN'))
+    unnecessary_function_calls = ['_prepare_benchmark',
+                                  'cagr',
+                                  'gain_to_pain_ratio',
+                                  'rolling_volatility',]
 
-    if rf > 0:
-        return to_excess_returns(data, rf, nperiods)
+
+    if function not in unnecessary_function_calls:
+        if rf > 0:
+            return to_excess_returns(data, rf, nperiods)
     return data
 
 


### PR DESCRIPTION
Bug: when rf rate is used the _prepare_benchmark function is called twice before and subtracts the annual rf rate twice from both returns and benchmark data frames.

Temporary fix for issue #158: identity which function calls prepare_returns() and don't allow data frames to be cleaned via the to_excess_returns() function, only for certain functions is it allowed, such as Sharpe and Sortino ratios.

If you would like to see my testing on how i came to this conclusion, please see issue #158 