### PR TITLE
fixing saving HTML file

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -247,7 +247,7 @@ def html(returns, benchmark=None, rf=0., grayscale=False,
         _download_html(tpl, download_filename)
         return
 
-    with open(output, 'w', encoding='utf-8') as f:
+    with open(download_filename, 'w', encoding='utf-8') as f:
         f.write(tpl)
 
 


### PR DESCRIPTION
This PR is to fix an issue where the `open` used for saving the HTML report is using the `output` variable instead of `download_filename`