### PR TITLE
Fix for benchmark name when supplied by the user

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -73,7 +73,18 @@ def html(returns, benchmark=None, rf=0., grayscale=False,
     # prepare timeseries
     returns = _utils._prepare_returns(returns)
     if benchmark is not None:
-        tpl = tpl.replace('{{benchmark_title}}', f"Benchmark is {benchmark} | ")
+        
+         def get_benchmark_title(bench):
+            if isinstance(bench, str):
+                return bench
+            elif isinstance(bench, _pd.Series):
+                return bench.name
+            elif isinstance(bench, _pd.DataFrame):
+                return bench[bench.columns[0]].name
+            else:
+                raise ValueError("Can't infer benchmark title")
+                
+        tpl = tpl.replace('{{benchmark_title}}', f"Benchmark is {get_benchmark_title(benchmark)} | ")
         benchmark = _utils._prepare_benchmark(benchmark, returns.index, rf)
         if match_dates is True:
             returns, benchmark = _match_dates(returns, benchmark)


### PR DESCRIPTION
When user passes benchmark data to `html` function, benchmark name is not displayed correctly, proposed fix will detect the correct name for the benchmark based on the type of benchmark passed
<img width="1022" alt="Screen Shot 2022-05-01 at 9 40 40 PM" src="https://user-images.githubusercontent.com/3959074/166161971-4d9cfe6d-0e93-45a3-911b-bc2a6d1002da.png">
