### PR TITLE
Multi-threads report generation for multiple assets at once

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -82,7 +82,7 @@ def generate_report(df,
 
     result_df = [p for p in pool.map(calculate_metrics_in_pool, tickers)]
 
-    return pd.concat(result_df, axis=1).T
+    return _pd.concat(result_df, axis=1).T
 
 
 def html(returns, benchmark=None, rf=0., grayscale=False,


### PR DESCRIPTION
I added generate_reports function in reports.py which allows creating reports for multiple assets (or strategies) concurrently.
Using a customized "metrics" version - custom_metrics function in reports.py: removing "%" at the end of all metric names and replacing " " with "_".

Sample input: 
`
qs.reports.generate_report(compare_df, periods_per_year=365)
`
with compare_df is DataFrame as following
![image](https://user-images.githubusercontent.com/17061986/168227521-f8ae0890-41aa-49c9-8159-04a30ffa4672.png)

Sample output (DataFrame):
![image](https://user-images.githubusercontent.com/17061986/168227431-025bf83c-ca1a-401d-b961-4d8b848dcde0.png)

