### PR TITLE
Fix EOY compound return bug

### DIFF
--- a/quantstats/stats.py
+++ b/quantstats/stats.py
@@ -979,7 +979,9 @@ def monthly_returns(returns, eoy=True, compounded=True, prepare_returns=True):
 
     if eoy:
         returns['eoy'] = _utils.group_returns(
-            original_returns, original_returns.index.year).values
+            original_returns, 
+            original_returns.index.year, 
+            compounded=compounded).values
 
     returns.columns = map(lambda x: str(x).upper(), returns.columns)
     returns.index.name = None


### PR DESCRIPTION
The end of year (EOY) compounded returns calculated by `stats.monthly_returns()` were not being properly calculated.

You can confirm the bug with the following code on the existing repo:
```
import quantstats as qs
qs.extend_pandas()
stock = qs.utils.download_returns('META')
rets = stock.monthly_returns().iloc[1][0:12]
eoy = stock.monthly_returns().iloc[1][12]
print(rets)
print(f'Original compound end of year return = {eoy}')  # shows 0.82
compret = rets.add(1).prod() - 1
print(f'Correct compound return should be = {compret}')  # shows 1.05
```

This PR fixes the bug.