### PR TITLE
add prepare_returns inside prepare_benchmark and make_index

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -326,7 +326,7 @@ def basic(returns, benchmark=None, rf=0., grayscale=False,
     # prepare timeseries
     returns = _utils._prepare_returns(returns)
     if benchmark is not None:
-        benchmark = _utils._prepare_benchmark(benchmark, returns.index, rf)
+        benchmark = _utils._prepare_benchmark(benchmark, returns.index)
         if match_dates is True:
             returns, benchmark = _match_dates(returns, benchmark)
 

--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -326,7 +326,7 @@ def basic(returns, benchmark=None, rf=0., grayscale=False,
     # prepare timeseries
     returns = _utils._prepare_returns(returns)
     if benchmark is not None:
-        benchmark = _utils._prepare_benchmark(benchmark, returns.index)
+        benchmark = _utils._prepare_benchmark(benchmark, returns.index, rf)
         if match_dates is True:
             returns, benchmark = _match_dates(returns, benchmark)
 

--- a/quantstats/utils.py
+++ b/quantstats/utils.py
@@ -243,8 +243,7 @@ def download_returns(ticker, period="max"):
     return _yf.Ticker(ticker).history(**p)['Close'].pct_change()
 
 
-def _prepare_benchmark(benchmark=None, period="max", rf=0.,
-                       prepare_returns=True):
+def _prepare_benchmark(benchmark=None, period="max"):
     """
     Fetch benchmark if ticker is provided, and pass through
     _prepare_returns()
@@ -260,6 +259,8 @@ def _prepare_benchmark(benchmark=None, period="max", rf=0.,
     elif isinstance(benchmark, _pd.DataFrame):
         benchmark = benchmark[benchmark.columns[0]].copy()
 
+    benchmark = _prepare_returns(benchmark)
+
     if isinstance(period, _pd.DatetimeIndex) \
         and set(period) != set(benchmark.index):
 
@@ -270,9 +271,7 @@ def _prepare_benchmark(benchmark=None, period="max", rf=0.,
             .reindex(period).pct_change().fillna(0)
         benchmark = benchmark[benchmark.index.isin(period)]
 
-    if prepare_returns:
-        return _prepare_returns(benchmark.dropna(), rf=rf)
-    return benchmark.dropna()
+    return benchmark
 
 
 def _round_to_closest(val, res, decimals=None):
@@ -354,7 +353,7 @@ def make_index(ticker_weights, rebalance="1M", period="max", returns=None, match
         else:
             ticker_returns = returns[ticker]
 
-        portfolio[ticker] = ticker_returns
+        portfolio[ticker] = _prepare_returns(ticker_returns)
 
     # index members time-series
     index = _pd.DataFrame(portfolio).dropna()

--- a/quantstats/utils.py
+++ b/quantstats/utils.py
@@ -243,7 +243,7 @@ def download_returns(ticker, period="max"):
     return _yf.Ticker(ticker).history(**p)['Close'].pct_change()
 
 
-def _prepare_benchmark(benchmark=None, period="max"):
+def _prepare_benchmark(benchmark=None, period="max", rf=0.):
     """
     Fetch benchmark if ticker is provided, and pass through
     _prepare_returns()
@@ -259,7 +259,7 @@ def _prepare_benchmark(benchmark=None, period="max"):
     elif isinstance(benchmark, _pd.DataFrame):
         benchmark = benchmark[benchmark.columns[0]].copy()
 
-    benchmark = _prepare_returns(benchmark)
+    benchmark = _prepare_returns(benchmark, rf)
 
     if isinstance(period, _pd.DatetimeIndex) \
         and set(period) != set(benchmark.index):
@@ -353,7 +353,7 @@ def make_index(ticker_weights, rebalance="1M", period="max", returns=None, match
         else:
             ticker_returns = returns[ticker]
 
-        portfolio[ticker] = _prepare_returns(ticker_returns)
+        portfolio[ticker] = ticker_returns
 
     # index members time-series
     index = _pd.DataFrame(portfolio).dropna()


### PR DESCRIPTION
This PR fixes an unexpected result when a ticker is compared with a benchmark.

If the ticker and the benchmark are identical, the metrics in the report should be identical as well.

In the basic report, the returns of the ticker are prepared:
`returns = _utils._prepare_returns(returns)`

Hence, to get consistent results, the benchmark should also be prepared.

## Code to show old benchmark gives inconsistent metrics

```
import quantstats as qs

qs.extend_pandas()
TICKER = 'SPY'
returns = qs.utils.download_returns(TICKER)

# Create report. Note inconsistent 'Cumulative Return'.
metrics = qs.reports.basic(returns, returns)
```
