### PR TITLE
Remove timezone from benchmark if exist

### DIFF
--- a/quantstats/utils.py
+++ b/quantstats/utils.py
@@ -262,10 +262,15 @@ def _prepare_benchmark(benchmark=None, period="max", rf=0.,
 
     if isinstance(period, _pd.DatetimeIndex) \
         and set(period) != set(benchmark.index):
-
+        
         # Adjust Benchmark to Strategy frequency
         benchmark_prices = to_prices(benchmark, base=1)
         new_index = _pd.date_range(start=period[0], end=period[-1], freq='D')
+        
+        if benchmark_prices.index[0].tzname() is not None:
+        # remove timezone info as well as time
+            benchmark_prices.index = benchmark_prices.index.date
+        
         benchmark = benchmark_prices.reindex(new_index, method='bfill') \
             .reindex(period).pct_change().fillna(0)
         benchmark = benchmark[benchmark.index.isin(period)]


### PR DESCRIPTION
Fixed TypeError: Cannot compare dtypes datetime64[ns, America/New_York] and datetime64[ns]