### PR TITLE
write report in correct file path

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -259,7 +259,7 @@ def html(returns, benchmark=None, rf=0., grayscale=False,
         _download_html(tpl, download_filename)
         return
 
-    with open(download_filename, 'w', encoding='utf-8') as f:
+    with open(output, 'w', encoding='utf-8') as f:
         f.write(tpl)
 
 


### PR DESCRIPTION
write report in input output variable instead of default download_filename variable