### PR TITLE
Automatically update GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Problem:
- GitHub Actions are versioned. There is currently no way of automatically updating to the latest actions.

Solution:
- Have dependabot update GitHub Actions.