### PR TITLE
Update reports.py

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -34,7 +34,7 @@ from . import (
 from dateutil.relativedelta import relativedelta
 
 try:
-    from IPython.core.display import (
+    from IPython.display import (
         display as iDisplay, HTML as iHTML
     )
 except ImportError:


### PR DESCRIPTION
Fixed import due to depracation warning below:
Importing display from IPython.core.display is deprecated since IPython 7.14, please import from IPython display