### PR TITLE
Update utils.py - fix issue 273 , make_index not working

### DIFF
--- a/quantstats/utils.py
+++ b/quantstats/utils.py
@@ -397,7 +397,7 @@ def make_index(
 
     # drop when all are NaN
     index.dropna(how="all", inplace=True)
-    return index[index.index <= last_day].sum(axis=1)
+    return index[index.index <= last_day][portfolio.keys()].sum(axis=1)
 
 
 def make_portfolio(returns, start_balance=1e5, mode="comp", round_to=None):


### PR DESCRIPTION
make_index doesnt work because 'break' column is str which makes the sum(axis=1) fail. issue [273](https://github.com/ranaroussi/quantstats/issues/273)

this fix will only use the columns in the original ticker_weights

an alternate fix (not included here) would be to include 'breaks' column in drop line

`index.drop(columns=["first_day", "breaks"], inplace=True)`