### PR TITLE
Fix a bug occurring when prepare_returns is invoked in metrics

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -763,7 +763,7 @@ def metrics(
     #     returns = returns[returns.columns[0]]
 
     if prepare_returns:
-        df = _utils._prepare_returns(returns)
+        returns = _utils._prepare_returns(returns)
 
     if isinstance(returns, _pd.Series):
         df = _pd.DataFrame({"returns": returns})


### PR DESCRIPTION
Addressing issue: https://github.com/ranaroussi/quantstats/issues/272