### PR TITLE
changed CAGR default preiods to 365 from 252

### DIFF
--- a/quantstats/stats.py
+++ b/quantstats/stats.py
@@ -512,7 +512,7 @@ def gain_to_pain_ratio(returns, rf=0, resolution="D"):
     return returns.sum() / downside
 
 
-def cagr(returns, rf=0.0, compounded=True, periods=252):
+def cagr(returns, rf=0.0, compounded=True, periods=365):
     """
     Calculates the communicative annualized growth return
     (CAGR%) of access returns


### PR DESCRIPTION
When calculating CAGR, you are using calendar year of 365 days (see https://www.investopedia.com/terms/c/cagr.asp#:~:text=To%20calculate%20the%20CAGR%20of,one%20from%20the%20subsequent%20result.)

Using 252 periods is wrong and will produce misleading CAGR.

For a simple example:
Say the between 2022-01-01 and 2022-12-31, I turned $100 to $200.
My return is 100% and my CAGR is 100%
Using 252 periods, my CAGR would be 61.83%, which is totally wrong.