### PR TITLE
Fix download returns

### DIFF
--- a/quantstats/stats.py
+++ b/quantstats/stats.py
@@ -512,7 +512,7 @@ def gain_to_pain_ratio(returns, rf=0, resolution="D"):
     return returns.sum() / downside
 
 
-def cagr(returns, rf=0.0, compounded=True, periods=252):
+def cagr(returns, rf=0.0, compounded=True, periods=365):
     """
     Calculates the communicative annualized growth return
     (CAGR%) of access returns

--- a/quantstats/utils.py
+++ b/quantstats/utils.py
@@ -239,7 +239,7 @@ def download_returns(ticker, period="max", proxy=None):
         params["start"] = period[0]
     else:
         params["period"] = period
-    return _yf.download(**params)["Close"].pct_change()
+    return _yf.download(**params, progress=False, threads=False)["Close"].rename(ticker).pct_change()
 
 
 def _prepare_benchmark(benchmark=None, period="max", rf=0.0, prepare_returns=True):


### PR DESCRIPTION
This PR is for fixing 3 issues in the `utils.download_returns` method:

1. There's no need for progress bar when downloading only 1 ticker
2. There's no need for multithreading when downloading only one ticker. This actually caused issue when running inside Flask
3. Rename the downloaded returns to the ticker's name instead of "Close". This affects the tearsheet.