### PR TITLE
Minor change allows matplotlib to display plots, closes #320. 

### DIFF
--- a/quantstats/_plotting/core.py
+++ b/quantstats/_plotting/core.py
@@ -230,7 +230,7 @@ def plot_returns_bars(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -393,7 +393,7 @@ def plot_timeseries(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -588,7 +588,7 @@ def plot_histogram(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -717,7 +717,7 @@ def plot_rolling_stats(
         else:
             _plt.savefig(savefig)
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -864,7 +864,7 @@ def plot_rolling_beta(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -979,7 +979,7 @@ def plot_longest_drawdowns(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -1092,7 +1092,7 @@ def plot_distribution(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -1184,7 +1184,7 @@ def plot_table(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 


### PR DESCRIPTION
Hi Ran, this PR is to enable matplotlib to display plots when the show argument is set to true, previously the functionality was set so that the script execution was not interrupted by plots however, I feel if the user is setting `show=True` then we should interrupt execution to display the plots? What do you think? This closes #320.

```python 
    if show:
        _plt.show(block=True)

    _plt.close()
```