### PR TITLE
Update quantstats.reports.metrics to include key dates of maximum drawdown. 

### DIFF
--- a/quantstats/_plotting/core.py
+++ b/quantstats/_plotting/core.py
@@ -230,7 +230,7 @@ def plot_returns_bars(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -393,7 +393,7 @@ def plot_timeseries(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -588,7 +588,7 @@ def plot_histogram(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -717,7 +717,7 @@ def plot_rolling_stats(
         else:
             _plt.savefig(savefig)
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -864,7 +864,7 @@ def plot_rolling_beta(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -979,7 +979,7 @@ def plot_longest_drawdowns(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -1092,7 +1092,7 @@ def plot_distribution(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 
@@ -1184,7 +1184,7 @@ def plot_table(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=False)
+        _plt.show(block=True)
 
     _plt.close()
 

--- a/quantstats/_plotting/core.py
+++ b/quantstats/_plotting/core.py
@@ -230,7 +230,7 @@ def plot_returns_bars(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=True)
+        _plt.show(block=False)
 
     _plt.close()
 
@@ -393,7 +393,7 @@ def plot_timeseries(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=True)
+        _plt.show(block=False)
 
     _plt.close()
 
@@ -588,7 +588,7 @@ def plot_histogram(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=True)
+        _plt.show(block=False)
 
     _plt.close()
 
@@ -717,7 +717,7 @@ def plot_rolling_stats(
         else:
             _plt.savefig(savefig)
     if show:
-        _plt.show(block=True)
+        _plt.show(block=False)
 
     _plt.close()
 
@@ -864,7 +864,7 @@ def plot_rolling_beta(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=True)
+        _plt.show(block=False)
 
     _plt.close()
 
@@ -979,7 +979,7 @@ def plot_longest_drawdowns(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=True)
+        _plt.show(block=False)
 
     _plt.close()
 
@@ -1092,7 +1092,7 @@ def plot_distribution(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=True)
+        _plt.show(block=False)
 
     _plt.close()
 
@@ -1184,7 +1184,7 @@ def plot_table(
             _plt.savefig(savefig)
 
     if show:
-        _plt.show(block=True)
+        _plt.show(block=False)
 
     _plt.close()
 

--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -66,7 +66,6 @@ def html(
     match_dates=True,
     **kwargs,
 ):
-
     if output is None and not _utils._in_notebook():
         raise ValueError("`output` must be specified")
 
@@ -501,7 +500,6 @@ def full(
     match_dates=True,
     **kwargs,
 ):
-
     # prepare timeseries
     if match_dates:
         returns = returns.dropna()
@@ -651,7 +649,6 @@ def basic(
     match_dates=True,
     **kwargs,
 ):
-
     # prepare timeseries
     if match_dates:
         returns = returns.dropna()
@@ -731,7 +728,6 @@ def metrics(
     match_dates=True,
     **kwargs,
 ):
-
     if match_dates:
         returns = returns.dropna()
     returns.index = returns.index.tz_localize(None)
@@ -816,13 +812,6 @@ def metrics(
     if kwargs.get("as_pct", False):
         pct = 100
 
-    # return df
-    dd = _calc_dd(
-        df,
-        display=(display or "internal" in kwargs),
-        as_pct=kwargs.get("as_pct", False),
-    )
-
     metrics = _pd.DataFrame()
     metrics["Start Period"] = _pd.Series(s_start)
     metrics["End Period"] = _pd.Series(s_end)
@@ -863,6 +852,9 @@ def metrics(
 
     metrics["~~~~~~~~"] = blank
     metrics["Max Drawdown %"] = blank
+    metrics["Max Drawdown Date"] = blank
+    metrics["Max Drawdown Period Start"] = blank
+    metrics["Max Drawdown Period End"] = blank
     metrics["Longest DD Days"] = blank
 
     if mode.lower() == "full":
@@ -930,13 +922,20 @@ def metrics(
         metrics["~~~~~~~~~~"] = blank
 
         metrics["Expected Daily %%"] = (
-            _stats.expected_return(df, compounded=compounded, prepare_returns=False) * pct
+            _stats.expected_return(df, compounded=compounded, prepare_returns=False)
+            * pct
         )
         metrics["Expected Monthly %%"] = (
-            _stats.expected_return(df, compounded=compounded, aggregate="M", prepare_returns=False) * pct
+            _stats.expected_return(
+                df, compounded=compounded, aggregate="M", prepare_returns=False
+            )
+            * pct
         )
         metrics["Expected Yearly %%"] = (
-            _stats.expected_return(df, compounded=compounded, aggregate="A", prepare_returns=False) * pct
+            _stats.expected_return(
+                df, compounded=compounded, aggregate="A", prepare_returns=False
+            )
+            * pct
         )
         metrics["Kelly Criterion %"] = (
             _stats.kelly_criterion(df, prepare_returns=False) * pct
@@ -1004,25 +1003,40 @@ def metrics(
     # best/worst
     if mode.lower() == "full":
         metrics["~~~"] = blank
-        metrics["Best Day %"] = _stats.best(df, compounded=compounded, prepare_returns=False) * pct
+        metrics["Best Day %"] = (
+            _stats.best(df, compounded=compounded, prepare_returns=False) * pct
+        )
         metrics["Worst Day %"] = _stats.worst(df, prepare_returns=False) * pct
         metrics["Best Month %"] = (
-            _stats.best(df, compounded=compounded, aggregate="M", prepare_returns=False) * pct
+            _stats.best(df, compounded=compounded, aggregate="M", prepare_returns=False)
+            * pct
         )
         metrics["Worst Month %"] = (
             _stats.worst(df, aggregate="M", prepare_returns=False) * pct
         )
         metrics["Best Year %"] = (
-            _stats.best(df, compounded=compounded, aggregate="A", prepare_returns=False) * pct
+            _stats.best(df, compounded=compounded, aggregate="A", prepare_returns=False)
+            * pct
         )
         metrics["Worst Year %"] = (
-            _stats.worst(df, compounded=compounded, aggregate="A", prepare_returns=False) * pct
+            _stats.worst(
+                df, compounded=compounded, aggregate="A", prepare_returns=False
+            )
+            * pct
         )
 
-    # dd
+    # return drawdown (dd) df
+    dd = _calc_dd(
+        df,
+        display=(display or "internal" in kwargs),
+        as_pct=kwargs.get("as_pct", False),
+    )
+
+    # drawdown (dd) detail
     metrics["~~~~"] = blank
     for ix, row in dd.iterrows():
         metrics[ix] = row
+
     metrics["Recovery Factor"] = _stats.recovery_factor(df)
     metrics["Ulcer Index"] = _stats.ulcer_index(df)
     metrics["Serenity Index"] = _stats.serenity_index(df, rf)
@@ -1031,20 +1045,35 @@ def metrics(
     if mode.lower() == "full":
         metrics["~~~~~"] = blank
         metrics["Avg. Up Month %"] = (
-            _stats.avg_win(df, compounded=compounded, aggregate="M", prepare_returns=False) * pct
+            _stats.avg_win(
+                df, compounded=compounded, aggregate="M", prepare_returns=False
+            )
+            * pct
         )
         metrics["Avg. Down Month %"] = (
-            _stats.avg_loss(df, compounded=compounded, aggregate="M", prepare_returns=False) * pct
+            _stats.avg_loss(
+                df, compounded=compounded, aggregate="M", prepare_returns=False
+            )
+            * pct
         )
         metrics["Win Days %%"] = _stats.win_rate(df, prepare_returns=False) * pct
         metrics["Win Month %%"] = (
-            _stats.win_rate(df, compounded=compounded, aggregate="M", prepare_returns=False) * pct
+            _stats.win_rate(
+                df, compounded=compounded, aggregate="M", prepare_returns=False
+            )
+            * pct
         )
         metrics["Win Quarter %%"] = (
-            _stats.win_rate(df, compounded=compounded, aggregate="Q", prepare_returns=False) * pct
+            _stats.win_rate(
+                df, compounded=compounded, aggregate="Q", prepare_returns=False
+            )
+            * pct
         )
         metrics["Win Year %%"] = (
-            _stats.win_rate(df, compounded=compounded, aggregate="A", prepare_returns=False) * pct
+            _stats.win_rate(
+                df, compounded=compounded, aggregate="A", prepare_returns=False
+            )
+            * pct
         )
 
         if "benchmark" in df:
@@ -1212,7 +1241,6 @@ def plots(
     match_dates=True,
     **kwargs,
 ):
-
     benchmark_colname = kwargs.get("benchmark_title", "Benchmark")
     strategy_colname = kwargs.get("strategy_title", "Strategy")
     active = kwargs.get("active", "False")
@@ -1500,6 +1528,15 @@ def _calc_dd(df, display=True, as_pct=False):
                 .sort_values(by="max drawdown", ascending=True)["max drawdown"]
                 .values[0]
                 / 100,
+                "Max Drawdown Date": ret_dd[col]
+                .sort_values(by="max drawdown", ascending=True)["valley"]
+                .values[0],
+                "Max Drawdown Period Start": ret_dd[col]
+                .sort_values(by="max drawdown", ascending=True)["start"]
+                .values[0],
+                "Max Drawdown Period End": ret_dd[col]
+                .sort_values(by="max drawdown", ascending=True)["end"]
+                .values[0],
                 "Longest DD Days": str(
                     _np.round(
                         ret_dd[col]
@@ -1519,6 +1556,15 @@ def _calc_dd(df, display=True, as_pct=False):
                     "max drawdown"
                 ].values[0]
                 / 100,
+                "Max Drawdown Date": ret_dd.sort_values(
+                    by="max drawdown", ascending=True
+                )["valley"].values[0],
+                "Max Drawdown Period Start": ret_dd.sort_values(
+                    by="max drawdown", ascending=True
+                )["start"].values[0],
+                "Max Drawdown Period End": ret_dd.sort_values(
+                    by="max drawdown", ascending=True
+                )["end"].values[0],
                 "Longest DD Days": str(
                     _np.round(
                         ret_dd.sort_values(by="days", ascending=False)["days"].values[0]
@@ -1535,6 +1581,15 @@ def _calc_dd(df, display=True, as_pct=False):
                 "max drawdown"
             ].values[0]
             / 100,
+            "Max Drawdown Date": bench_dd.sort_values(
+                by="max drawdown", ascending=True
+            )["valley"].values[0],
+            "Max Drawdown Period Start": bench_dd.sort_values(
+                by="max drawdown", ascending=True
+            )["start"].values[0],
+            "Max Drawdown Period End": bench_dd.sort_values(
+                by="max drawdown", ascending=True
+            )["end"].values[0],
             "Longest DD Days": str(
                 _np.round(
                     bench_dd.sort_values(by="days", ascending=False)["days"].values[0]


### PR DESCRIPTION
Hi @ranaroussi , 

I have submitted this PR to enable users to see the maximum drawdown dates (maximum drawdown date itself, start and end) as part of the quantstats.reports.metrics. The dates themselves were already part of the library just not visible in the metrics report (hence relatively minor change). I noticed you have previously reformatted using `black` so have done so on the file modified as part of this PR (`reports.py`). Having these readily available in the metrics export will add a bunch of value for end users particularly when comparing multi-asset portfolios to a benchmark. This PR closes #318.

New output looks as follows with new metrics highlighted. 
![image](https://github.com/ranaroussi/quantstats/assets/25130636/e32cae58-a983-4038-93cc-dbe64ddb7faf)


Kind regards,
git-shogg