### PR TITLE
close plt only if shown

### DIFF
--- a/quantstats/_plotting/wrappers.py
+++ b/quantstats/_plotting/wrappers.py
@@ -255,8 +255,7 @@ def snapshot(
 
     if show:
         _plt.show(block=False)
-
-    _plt.close()
+        _plt.close()
 
     if not show:
         return fig
@@ -363,8 +362,7 @@ def earnings(
 
     if show:
         _plt.show(block=False)
-
-    _plt.close()
+        _plt.close()
 
     if not show:
         return fig
@@ -1051,8 +1049,7 @@ def monthly_heatmap(
 
     if show:
         _plt.show(block=False)
-
-    _plt.close()
+        _plt.close()
 
     if not show:
         return fig


### PR DESCRIPTION
* Closing the plt before returning the figure renders it useless. Therefore we should close the plt only if shown.