### PR TITLE
Respect boolean parameter ylabel (disable when False)

### DIFF
--- a/quantstats/_plotting/core.py
+++ b/quantstats/_plotting/core.py
@@ -564,9 +564,18 @@ def plot_histogram(
     # ax.axvline(0, lw=1, color="#000000", zorder=2)
 
     ax.set_xlabel("")
-    ax.set_ylabel(
-        "Occurrences", fontname=fontname, fontweight="bold", fontsize=12, color="black"
-    )
+
+    if ylabel:
+        ax.set_ylabel(
+            "Occurrences",
+            fontname=fontname,
+            fontweight="bold",
+            fontsize=12,
+            color="black"
+        )
+    else:
+        ax.set_ylabel(None)
+
     ax.yaxis.set_label_coords(-0.1, 0.5)
 
     # fig.autofmt_xdate()


### PR DESCRIPTION
Currently, the parameter =ylabel= is ignored and the hard-coded ylable is written regardless of the =ylable= parameter is truthy or falsy.

This change will not set an ylable for the chart if the =ylable= parameter is set to a falsy value.

In a next step one could check if =ylable= is a String and if so, set the actual ylable string to that string.