### PR TITLE
[bug] AttributeError: module 'numpy' has no attribute 'product'

### DIFF
--- a/quantstats/stats.py
+++ b/quantstats/stats.py
@@ -93,7 +93,9 @@ def expected_return(returns, aggregate=None, compounded=True, prepare_returns=Tr
     if prepare_returns:
         returns = _utils._prepare_returns(returns)
     returns = _utils.aggregate_returns(returns, aggregate, compounded)
-    return _np.product(1 + returns) ** (1 / len(returns)) - 1
+    if _np.__version__.startswith("1."):
+        return _np.product(1 + returns) ** (1 / len(returns)) - 1
+    return _np.prod(1 + returns) ** (1 / len(returns)) - 1
 
 
 def geometric_mean(retruns, aggregate=None, compounded=True):


### PR DESCRIPTION
# Issue

The `_np.product` deprecated in `numpy` 2.X update.

```shell
AttributeError: module 'numpy' has no attribute 'product'
```

# Solution

- Implement `numpy` version detection before calling the `numpy.product`, for `numpy>=2.0` `numpy.prod` would be used