### PR TITLE
Fix UnsupportedFunctionCal 

### DIFF
--- a/quantstats/_plotting/core.py
+++ b/quantstats/_plotting/core.py
@@ -290,11 +290,9 @@ def plot_timeseries(
                 benchmark = benchmark.cumsum()
 
     if resample:
-        returns = returns.resample(resample)
-        returns = returns.last() if compound is True else returns.sum(axis=0)
+        returns = returns.resample(resample).last() if compound else returns.resample(resample).sum()
         if isinstance(benchmark, _pd.Series):
-            benchmark = benchmark.resample(resample)
-            benchmark = benchmark.last() if compound is True else benchmark.sum(axis=0)
+            benchmark = benchmark.resample(resample).last() if compound else benchmark.resample(resample).sum()
     # ---------------
 
     fig, ax = _plt.subplots(figsize=figsize)


### PR DESCRIPTION
ERROR:
 qs.reports.full(returns, mode='full', benchmark=benchmark)
  File "C:\ProgramData\miniconda3\envs\bbsdev\lib\site-packages\quantstats\reports.py", line 628, in full
    plots(
  File "C:\ProgramData\miniconda3\envs\bbsdev\lib\site-packages\quantstats\reports.py", line 1346, in plots
    _plots.daily_returns(
  File "C:\ProgramData\miniconda3\envs\bbsdev\lib\site-packages\quantstats\_plotting\wrappers.py", line 512, in daily_returns
    fig = _core.plot_timeseries(
  File "C:\ProgramData\miniconda3\envs\bbsdev\lib\site-packages\quantstats\_plotting\core.py", line 294, in plot_timeseries
    returns = returns.last() if compound is True else returns.sum(axis=0)
  File "C:\ProgramData\miniconda3\envs\bbsdev\lib\site-packages\pandas\core\resample.py", line 1183, in sum
    nv.validate_resampler_func("sum", args, kwargs)
  File "C:\ProgramData\miniconda3\envs\bbsdev\lib\site-packages\pandas\compat\numpy\function.py", line 376, in validate_resampler_func
    raise UnsupportedFunctionCall(
pandas.errors.UnsupportedFunctionCall: numpy operations are not valid with resample. Use .resample(...).sum() instead
