### PR TITLE
Fix the issue with the example on the tearsheet. Update README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ Quick Start
     qs.extend_pandas()
 
     # fetch the daily returns for a stock
-    stock = qs.utils.download_returns('META')
+    stock = qs.utils.download_returns("META")["META"]
 
     # show sharpe ratio
     qs.stats.sharpe(stock)


### PR DESCRIPTION
When data is fetched in the example, it returns pd.DataFrame, not pd.Series. It leads to error in further functions.
```
# fetch the daily returns for a stock
stock = qs.utils.download_returns('META')
```
When the data is converted to pd.Series, functions work well.