### PR TITLE
Removing unnecessary axis numpy argument to fix UnsupportedFunctionCa…

### DIFF
--- a/quantstats/_plotting/core.py
+++ b/quantstats/_plotting/core.py
@@ -291,10 +291,10 @@ def plot_timeseries(
 
     if resample:
         returns = returns.resample(resample)
-        returns = returns.last() if compound is True else returns.sum(axis=0)
+        returns = returns.last() if compound is True else returns.sum()
         if isinstance(benchmark, _pd.Series):
             benchmark = benchmark.resample(resample)
-            benchmark = benchmark.last() if compound is True else benchmark.sum(axis=0)
+            benchmark = benchmark.last() if compound is True else benchmark.sum()
     # ---------------
 
     fig, ax = _plt.subplots(figsize=figsize)


### PR DESCRIPTION
…ll error when resampling

pandas.errors.UnsupportedFunctionCall: numpy operations are not valid with resample. Use .resample(...).sum() instead