### PR TITLE
Change of the CAGR calculation

### DIFF
--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -836,7 +836,7 @@ def metrics(
     else:
         metrics["Total Return %"] = (df.sum() * pct).map("{:,.2f}".format)
 
-    metrics["CAGR﹪%"] = _stats.cagr(df, rf, compounded) * pct
+    metrics["CAGR﹪%"] = _stats.cagr(df, rf, compounded, win_year) * pct
 
     metrics["~~~~~~~~~~~~~~"] = blank
 

--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -993,15 +993,15 @@ def metrics(
         metrics["1Y %"] = _np.sum(df[df.index >= y1], axis=0) * pct
 
     d = today - relativedelta(months=35)
-    metrics["3Y (ann.) %"] = _stats.cagr(df[df.index >= d], 0.0, compounded) * pct
+    metrics["3Y (ann.) %"] = _stats.cagr(df[df.index >= d], 0.0, compounded, win_year) * pct
 
     d = today - relativedelta(months=59)
-    metrics["5Y (ann.) %"] = _stats.cagr(df[df.index >= d], 0.0, compounded) * pct
+    metrics["5Y (ann.) %"] = _stats.cagr(df[df.index >= d], 0.0, compounded, win_year) * pct
 
     d = today - relativedelta(years=10)
-    metrics["10Y (ann.) %"] = _stats.cagr(df[df.index >= d], 0.0, compounded) * pct
+    metrics["10Y (ann.) %"] = _stats.cagr(df[df.index >= d], 0.0, compounded, win_year) * pct
 
-    metrics["All-time (ann.) %"] = _stats.cagr(df, 0.0, compounded) * pct
+    metrics["All-time (ann.) %"] = _stats.cagr(df, 0.0, compounded, win_year) * pct
 
     # best/worst
     if mode.lower() == "full":


### PR DESCRIPTION
There was a bug where the period per year is not taken into consideration for the CAGR calculation and it always uses the default 252, which is unreasonable for 365-days-trading market like crypto