### PR TITLE
Issues when using compounded=False

### DIFF
--- a/quantstats/_plotting/wrappers.py
+++ b/quantstats/_plotting/wrappers.py
@@ -27,6 +27,7 @@ from matplotlib.ticker import (
 
 import numpy as _np
 from pandas import DataFrame as _df
+from pandas import Series as _series
 import pandas as _pd
 import seaborn as _sns
 
@@ -566,7 +567,7 @@ def yearly_returns(
     if compounded:
         returns = returns.resample("YE").apply(_stats.comp)
     else:
-        returns = returns.resample("YE").apply(_df.sum)
+        returns = returns.resample("YE").apply(_series.sum if isinstance(returns,_series) else _df.sum)
     returns = returns.resample("YE").last()
 
     fig = _core.plot_returns_bars(

--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -1292,7 +1292,8 @@ def plots(
         grayscale=grayscale,
         figsize=(figsize[0], figsize[0] * 0.6),
         show=True,
-        ylabel='',
+        ylabel=False,
+        cumulative=compounded,
         prepare_returns=False,
     )
 
@@ -1302,7 +1303,8 @@ def plots(
         grayscale=grayscale,
         figsize=(figsize[0], figsize[0] * 0.5),
         show=True,
-        ylabel='',
+        ylabel=False,
+        cumulative=compounded,
         prepare_returns=False,
     )
 
@@ -1314,7 +1316,8 @@ def plots(
             grayscale=grayscale,
             figsize=(figsize[0], figsize[0] * 0.5),
             show=True,
-            ylabel='',
+            ylabel=False,
+            cumulative=compounded,
             prepare_returns=False,
         )
 
@@ -1324,7 +1327,8 @@ def plots(
         grayscale=grayscale,
         figsize=(figsize[0], figsize[0] * 0.5),
         show=True,
-        ylabel='',
+        ylabel=False,
+        compounded=compounded,
         prepare_returns=False,
     )
 
@@ -1334,7 +1338,8 @@ def plots(
         grayscale=grayscale,
         figsize=(figsize[0], figsize[0] * 0.5),
         show=True,
-        ylabel='',
+        ylabel=False,
+        compounded=compounded,
         prepare_returns=False,
     )
 
@@ -1403,7 +1408,8 @@ def plots(
             grayscale=grayscale,
             figsize=(figsize[0], figsize[0] * 0.5),
             show=True,
-            ylabel='',
+            ylabel=False,
+            compounded=compounded,
             prepare_returns=False,
         )
     elif isinstance(returns, _pd.DataFrame):
@@ -1413,11 +1419,11 @@ def plots(
                 grayscale=grayscale,
                 figsize=(figsize[0], figsize[0] * 0.5),
                 show=True,
-                ylabel='',
+                ylabel=False,
                 title=col,
+                compounded=compounded,
                 prepare_returns=False,
             )
-
     _plots.drawdown(
         returns,
         grayscale=grayscale,
@@ -1433,6 +1439,7 @@ def plots(
             grayscale=grayscale,
             figsize=(figsize[0], figsize[0] * 0.5),
             returns_label=returns.name,
+            compounded=compounded,
             show=True,
             ylabel='',
             active=active,
@@ -1458,7 +1465,8 @@ def plots(
             figsize=(figsize[0], figsize[0] * 0.5),
             show=True,
             title=returns.name,
-            ylabel='',
+            ylabel=False,
+            compounded=compounded,
             prepare_returns=False,
         )
     elif isinstance(returns, _pd.DataFrame):
@@ -1469,10 +1477,10 @@ def plots(
                 figsize=(figsize[0], figsize[0] * 0.5),
                 show=True,
                 title=col,
-                ylabel='',
+                ylabel=False,
+                compounded=compounded,
                 prepare_returns=False,
             )
-
 
 def _calc_dd(df, display=True, as_pct=False):
     dd = _stats.to_drawdown_series(df)

--- a/quantstats/reports.py
+++ b/quantstats/reports.py
@@ -636,6 +636,7 @@ def full(
         benchmark_title=benchmark_title,
         strategy_title=strategy_title,
         active=active,
+        compounded=compounded,
     )
 
 
@@ -715,6 +716,7 @@ def basic(
         benchmark_title=benchmark_title,
         strategy_title=strategy_title,
         active=active,
+        compounded=compounded,
     )
 
 


### PR DESCRIPTION
When analysing returns of strategies instead of the whole portfolio it is useful not to compound the returns as we want trades at all periods to be weighted the same. When compound = False the plots arising from the quantstats.reports.full() function did not have compounded argument included. The same error was in basic(). 

When running qs.reports.html() an error in qs.reports._plotting.wrappers.yearly_returns() arose due to the assumption that returns would be a DataFrame. You can either use a fix similar to fine or convert all Series into DataFrame like you have in other sections.