### PR TITLE
Update core.py

### DIFF
--- a/quantstats/_plotting/core.py
+++ b/quantstats/_plotting/core.py
@@ -291,10 +291,10 @@ def plot_timeseries(
 
     if resample:
         returns = returns.resample(resample)
-        returns = returns.last() if compound is True else returns.sum(axis=0)
+        returns = returns.last() if compound is True else returns.sum()
         if isinstance(benchmark, _pd.Series):
             benchmark = benchmark.resample(resample)
-            benchmark = benchmark.last() if compound is True else benchmark.sum(axis=0)
+            benchmark = benchmark.last() if compound is True else benchmark.sum()
     # ---------------
 
     fig, ax = _plt.subplots(figsize=figsize)
@@ -1013,16 +1013,16 @@ def plot_distribution(
     apply_fnc = _stats.comp if compounded else _np.sum
 
     port["Weekly"] = port["Daily"].resample("W-MON").apply(apply_fnc)
-    port["Weekly"].ffill(inplace=True)
-
+    port["Weekly"] = port["Weekly"].ffill()
+ 
     port["Monthly"] = port["Daily"].resample("ME").apply(apply_fnc)
-    port["Monthly"].ffill(inplace=True)
-
+    port["Monthly"] = port["Monthly"].ffill()
+ 
     port["Quarterly"] = port["Daily"].resample("QE").apply(apply_fnc)
-    port["Quarterly"].ffill(inplace=True)
-
+    port["Quarterly"] = port["Quarterly"].ffill()
+ 
     port["Yearly"] = port["Daily"].resample("YE").apply(apply_fnc)
-    port["Yearly"].ffill(inplace=True)
+    port["Yearly"] = port["Yearly"].ffill()
 
     fig, ax = _plt.subplots(figsize=figsize)
     ax.spines["top"].set_visible(False)


### PR DESCRIPTION
chore(core): Adapt to changes in Pandas v2.2.3
﻿
- Remove deprecated `axis` parameter from sum() calls (lines 294-297)
* New Pandas 2.2.3 requires sum() to be called without axis parameter
- Replace deprecated `inplace=True` with assignment (lines 1015-1025)
* inplace parameter is no longer supported in DataFrame methods