### PR TITLE
Fix: single column/multiple columns returns in qs.reports.html

### DIFF
--- a/quantstats/_plotting/core.py
+++ b/quantstats/_plotting/core.py
@@ -291,7 +291,7 @@ def plot_timeseries(
 
     if resample:
         returns = returns.resample(resample)
-        returns = returns.last() if compound is True else returns.sum(axis=0)
+        returns = returns.last() if compound is True else returns.sum()
         if isinstance(benchmark, _pd.Series):
             benchmark = benchmark.resample(resample)
             benchmark = benchmark.last() if compound is True else benchmark.sum(axis=0)


### PR DESCRIPTION
This is a fix related to #378: reports.metrics failed to calculate Omega: KeyError: 'returns' (still not resolved in version 0.0.63).

In version 0.0.63, if a single column `returns` data is passed in to `qs.reports.html`, it will fail to generate the report successfully. The main issue is in `quantstats/reports.py`, the pass in data is not treated consistently. For single column dataframe, the column name of `return_1` should be expected, not `return`. 

The strategy_title also needs to be adjusted based on the number of columns of the input dataframe `returns`. 

The modified code has passed the test for both single column `returns` and multiple columns `returns`:

```python
qs.reports.html(returns, output='quantstats_report.html', title='Performance Report')
```