### PR TITLE
Tweak: add font availability check with fallback

### DIFF
--- a/quantstats/_plotting/wrappers.py
+++ b/quantstats/_plotting/wrappers.py
@@ -20,6 +20,7 @@
 
 import warnings
 import matplotlib.pyplot as _plt
+from matplotlib import font_manager
 from matplotlib.ticker import (
     StrMethodFormatter as _StrMethodFormatter,
     FuncFormatter as _FuncFormatter,
@@ -167,6 +168,11 @@ def snapshot(
     if figsize is None:
         size = list(_plt.gcf().get_size_inches())
         figsize = (size[0], size[0] * 0.75)
+
+    # Check if the requested font is available to prevent matplotlib warnings
+    if fontname not in [f.name for f in font_manager.fontManager.ttflist]:
+        print(f"Warning: Font '{fontname}' not found. Switching to 'DejaVu Sans'.")
+        fontname = 'DejaVu Sans'
 
     # Create figure with three subplots: cumulative returns, drawdown, daily returns
     fig, axes = _plt.subplots(


### PR DESCRIPTION
_(edit - Sorry, I didn't intend to open this here. I meant to open this PR from my side branch to my main branch, not to your repo. Though do feel free to merge if useful, I just haven't tested it anywhere besides my own machine.)_

## Summary
- Added font availability check to prevent matplotlib warnings when requested font is not installed
- Automatically falls back to 'DejaVu Sans' if the requested font is not available
- Prints a user-friendly warning message instead of letting matplotlib throw warnings on every plot

## Changes
- Import `font_manager` from matplotlib 
- Check if requested font exists in system fonts before using it
- Fallback to 'DejaVu Sans' (a standard font) if not found
- Print informative warning to user about the substitution