### PR TITLE
fix: resolve NaN value return in stats

### DIFF
--- a/quantstats/stats.py
+++ b/quantstats/stats.py
@@ -823,8 +823,18 @@ def autocorr_penalty(
     # returns.to_csv('/Users/ran/Desktop/test.csv')
     num = len(returns)
 
+    # Fix: corrcoef on fewer than 2 points is undefined and returns NaN
+    # with a RuntimeWarning, so bail out early with the neutral penalty
+    if num < 2:
+        return 1.0
+
     # Calculate autocorrelation coefficient between consecutive returns
     coef = _np.abs(_np.corrcoef(returns[:-1], returns[1:])[0, 1])
+
+    # Fix: zero-variance (constant) returns also make corrcoef return NaN,
+    # which would otherwise silently propagate through the sum below
+    if _np.isnan(coef):
+        return 1.0
 
     # Vectorized calculation instead of list comprehension
     x = _np.arange(1, num)


### PR DESCRIPTION
Fix: NaN handling in "autocorr_penalty" in stats.py
Added validation to prevent autocorr_penalty from returning NaN in edge cases.


Issues fixed:

1.Missing length check — Function didn't verify at least 2 data points existed. Short or identical-value series make the correlation calculation undefined hence returning NaN.

2.Unvalidated NaN propagation — A NaN coefficient would silently flow into downstream metrics like sharpe_ratio etc. No check existed to catch this before it spread.

Fix: Added early returns — if data points < 2, or coefficient is NaN, return neutral default 1.0 instead.